### PR TITLE
[Fix] BrowserViewの削除問題の修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -269,7 +269,8 @@ ipcMain.on('tabMove',(e,i)=>{
 })
 ipcMain.on('removeTab',(e,ind)=>{
   //source: https://www.gesource.jp/weblog/?p=4112
-  win.removeBrowserView(bv[ind])
+  win.removeBrowserView(bv[ind]);
+  bv[ind].webContents.destroy();
   bv.splice(ind,1);
 })
 


### PR DESCRIPTION
タブを閉じた際、内部的にはBrowserViewが削除されないためメモリリークが発生したり、音楽がずっと流れ続ける状況が発生する。
そのため内部的にはまだ存在する「WebContents#destroy」を実行してBrowserViewを削除する。