### PR TITLE
🐛 履歴に長文のタイトルがある場合にはみ出すのを枠内に収める

### DIFF
--- a/src/renderer/history/style/history.css
+++ b/src/renderer/history/style/history.css
@@ -47,10 +47,14 @@ h1 {
   background-position: center;
   background-repeat: no-repeat;
 }
+
 .history-details {
   width: 100%;
   height: 100%;
   padding-left: 15px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 


### PR DESCRIPTION
![image](https://github.com/mncrp/monot/assets/65443692/ba3f793a-593e-421a-8f50-f338988246ac)
これを
![image](https://github.com/mncrp/monot/assets/65443692/e66f2291-bd69-4766-a417-48e03306ee3c)
こういう風に治す。